### PR TITLE
Fixes #9283: stacktrace on opening foreman-sam app

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'SAM'
+end


### PR DESCRIPTION
Naming convention is looking for FormanSam instead of ForemanSAM.
